### PR TITLE
Implement Gmail MCP service bridging Gmail and ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
-# codex_testing
+# Gmail MCP Service
+
+This repository contains a FastAPI based service that exposes Gmail actions (list, summarize, send) through a lightweight HTTP API designed to be consumed from Model Context Protocol (MCP) compatible clients such as ChatGPT.
+
+## Features
+
+- OAuth2 authentication with Gmail using the official Google API client libraries.
+- Endpoints for listing messages, summarizing email content via ChatGPT, and sending emails.
+- Optional sender allow list for security.
+- Configuration via environment variables or a local `.env` file.
+
+## Project layout
+
+```
+.
+├── gmail_mcp_service
+│   ├── __init__.py
+│   ├── chatgpt_client.py
+│   ├── config.py
+│   ├── gmail_client.py
+│   ├── main.py
+│   └── service.py
+├── pyproject.toml
+├── README.md
+└── tests
+    └── test_imports.py
+```
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -e .[development]
+   ```
+
+2. **Create Google OAuth credentials**
+
+   - Visit the [Google Cloud Console](https://console.cloud.google.com/) and create an OAuth client (Desktop application).
+   - Download the `client_secret.json` file and store it locally.
+
+3. **Prepare environment variables**
+
+   Create a `.env` file in the project root containing:
+
+   ```env
+   GOOGLE_CLIENT_SECRET_FILE=/absolute/path/to/client_secret.json
+   GMAIL_TOKEN_FILE=/absolute/path/to/token.json
+   OPENAI_API_KEY=sk-your-openai-key
+   OPENAI_MODEL=gpt-4o-mini
+   ALLOWED_SENDERS=trusted@example.com,another@example.com
+   ```
+
+   The `GMAIL_TOKEN_FILE` will be generated automatically after the first successful OAuth flow.
+
+4. **Run the development server**
+
+   ```bash
+   uvicorn gmail_mcp_service.main:app --reload
+   ```
+
+   The service listens on `http://localhost:8000`. Swagger docs are available at `/docs`.
+
+5. **Configure ChatGPT MCP client**
+
+   In a ChatGPT MCP compatible client, add a tool configuration similar to:
+
+   ```json
+   {
+     "schema_version": "v1",
+     "name": "gmail",
+     "url": "http://localhost:8000",
+     "capabilities": {
+       "listMessages": {
+         "method": "GET",
+         "path": "/messages"
+       },
+       "summarizeMessage": {
+         "method": "POST",
+         "path": "/summaries"
+       },
+       "sendEmail": {
+         "method": "POST",
+         "path": "/send"
+       }
+     }
+   }
+   ```
+
+   Refer to your MCP client documentation for the exact configuration syntax.
+
+## Security considerations
+
+- Restrict which senders can be processed via the `ALLOWED_SENDERS` environment variable.
+- Use per-user OAuth credentials and avoid sharing tokens.
+- Consider running the service behind HTTPS and a reverse proxy in production.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/gmail_mcp_service/__init__.py
+++ b/gmail_mcp_service/__init__.py
@@ -1,0 +1,13 @@
+"""Gmail MCP service package."""
+
+from .config import Settings
+from .gmail_client import GmailClient
+from .chatgpt_client import ChatGPTClient
+from .service import create_app
+
+__all__ = [
+    "Settings",
+    "GmailClient",
+    "ChatGPTClient",
+    "create_app",
+]

--- a/gmail_mcp_service/chatgpt_client.py
+++ b/gmail_mcp_service/chatgpt_client.py
@@ -1,0 +1,32 @@
+"""Simple wrapper around OpenAI's Chat Completions API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from openai import OpenAI
+
+from .config import Settings
+
+
+@dataclass
+class ChatMessage:
+    role: str
+    content: str
+
+
+class ChatGPTClient:
+    """Interact with OpenAI's Chat Completions API."""
+
+    def __init__(self, settings: Settings):
+        self._client = OpenAI(api_key=settings.openai_api_key)
+        self._model = settings.openai_model
+
+    def complete(self, messages: Iterable[ChatMessage], temperature: float = 0.2) -> str:
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": message.role, "content": message.content} for message in messages],
+            temperature=temperature,
+        )
+        return response.choices[0].message.content

--- a/gmail_mcp_service/config.py
+++ b/gmail_mcp_service/config.py
@@ -1,0 +1,52 @@
+"""Configuration helpers for the Gmail MCP service."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the service.
+
+    Values are pulled from environment variables or a ``.env`` file if present.
+    """
+
+    google_client_secret_file: Path = Field(
+        ..., env="GOOGLE_CLIENT_SECRET_FILE", description="Path to the OAuth client secret JSON file"
+    )
+    gmail_token_file: Path = Field(
+        default=Path("token.json"), env="GMAIL_TOKEN_FILE", description="Path to the OAuth token JSON file"
+    )
+    gmail_user_id: str = Field(default="me", env="GMAIL_USER_ID")
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    openai_model: str = Field(default="gpt-4o-mini", env="OPENAI_MODEL")
+    allowed_senders: Optional[str] = Field(
+        default=None,
+        env="ALLOWED_SENDERS",
+        description="Comma separated list of email addresses that are allowed to be processed. If not set all messages are allowed.",
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("google_client_secret_file", "gmail_token_file", pre=True)
+    def _expand_path(cls, value: str | Path) -> Path:
+        return Path(value).expanduser().resolve()
+
+    @property
+    def allowed_senders_list(self) -> list[str] | None:
+        if not self.allowed_senders:
+            return None
+        return [item.strip().lower() for item in self.allowed_senders.split(",") if item.strip()]
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return the cached :class:`Settings` instance."""
+
+    return Settings()

--- a/gmail_mcp_service/gmail_client.py
+++ b/gmail_mcp_service/gmail_client.py
@@ -1,0 +1,89 @@
+"""Gmail API helpers."""
+
+from __future__ import annotations
+
+import base64
+import email
+from typing import Iterable, Optional
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+from .config import Settings
+
+SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+]
+
+
+class GmailClient:
+    """Wrapper around the Gmail REST API."""
+
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        self._service = self._build_service(settings)
+
+    @staticmethod
+    def _build_service(settings: Settings):
+        creds: Optional[Credentials] = None
+        if settings.gmail_token_file.exists():
+            creds = Credentials.from_authorized_user_file(str(settings.gmail_token_file), SCOPES)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(str(settings.google_client_secret_file), SCOPES)
+                creds = flow.run_local_server(port=0)
+            settings.gmail_token_file.write_text(creds.to_json())
+        return build("gmail", "v1", credentials=creds)
+
+    def list_messages(self, query: str | None = None, max_results: int = 10) -> list[dict]:
+        response = (
+            self._service.users()
+            .messages()
+            .list(userId=self._settings.gmail_user_id, q=query, maxResults=max_results)
+            .execute()
+        )
+        return response.get("messages", [])
+
+    def get_message(self, message_id: str) -> dict:
+        return (
+            self._service.users()
+            .messages()
+            .get(userId=self._settings.gmail_user_id, id=message_id, format="full")
+            .execute()
+        )
+
+    def send_message(self, to: str, subject: str, body: str) -> dict:
+        message = email.message.EmailMessage()
+        message["To"] = to
+        message["From"] = self._settings.gmail_user_id
+        message["Subject"] = subject
+        message.set_content(body)
+
+        encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
+        return (
+            self._service.users()
+            .messages()
+            .send(userId=self._settings.gmail_user_id, body={"raw": encoded_message})
+            .execute()
+        )
+
+    @staticmethod
+    def extract_text_payload(parts: Iterable[dict]) -> str:
+        """Extract the first text/plain payload from the Gmail API message parts."""
+
+        for part in parts:
+            mime_type = part.get("mimeType")
+            if mime_type == "text/plain" and "data" in part.get("body", {}):
+                data = part["body"]["data"]
+                decoded = base64.urlsafe_b64decode(data.encode()).decode()
+                return decoded
+            if part.get("parts"):
+                nested = GmailClient.extract_text_payload(part["parts"])
+                if nested:
+                    return nested
+        return ""

--- a/gmail_mcp_service/main.py
+++ b/gmail_mcp_service/main.py
@@ -1,0 +1,15 @@
+"""Entrypoint for running the FastAPI app with uvicorn."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from .service import app
+
+
+def main() -> None:
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/gmail_mcp_service/service.py
+++ b/gmail_mcp_service/service.py
@@ -1,0 +1,106 @@
+"""FastAPI application exposing Gmail and ChatGPT actions."""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .chatgpt_client import ChatGPTClient, ChatMessage
+from .config import Settings, get_settings
+from .gmail_client import GmailClient
+
+
+class GmailMessage(BaseModel):
+    id: str
+    threadId: Optional[str] = None
+
+
+class SummarizeRequest(BaseModel):
+    message_id: str
+    prompt: Optional[str] = None
+
+
+class SummarizeResponse(BaseModel):
+    message_id: str
+    summary: str
+
+
+class DraftEmail(BaseModel):
+    to: str
+    subject: str
+    body: str
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Gmail MCP Service", version="0.1.0")
+
+    def get_gmail_client(settings: Annotated[Settings, Depends(get_settings)]):
+        return GmailClient(settings)
+
+    def get_chatgpt_client(settings: Annotated[Settings, Depends(get_settings)]):
+        return ChatGPTClient(settings)
+
+    @app.get("/messages", response_model=list[GmailMessage])
+    def list_messages(
+        gmail_client: Annotated[GmailClient, Depends(get_gmail_client)],
+        query: str | None = None,
+        max_results: int = 10,
+    ):
+        messages = gmail_client.list_messages(query=query, max_results=max_results)
+        return [GmailMessage(**message) for message in messages]
+
+    @app.post("/summaries", response_model=SummarizeResponse)
+    def summarize_message(
+        payload: SummarizeRequest,
+        gmail_client: Annotated[GmailClient, Depends(get_gmail_client)],
+        chatgpt_client: Annotated[ChatGPTClient, Depends(get_chatgpt_client)],
+    ):
+        message = gmail_client.get_message(payload.message_id)
+        if settings := get_settings().allowed_senders_list:
+            headers = {header["name"].lower(): header["value"] for header in message.get("payload", {}).get("headers", [])}
+            sender = headers.get("from", "").lower()
+            if sender and sender not in settings:
+                raise HTTPException(status_code=403, detail="Sender not allowed")
+        parts = message.get("payload", {}).get("parts", [])
+        body_text = gmail_client.extract_text_payload(parts) if parts else message.get("snippet", "")
+        if not body_text:
+            raise HTTPException(status_code=404, detail="Message body could not be extracted")
+        system_prompt = "You are an assistant that summarizes Gmail messages for the user."
+        user_prompt = payload.prompt or "Summarize this email concisely."
+        summary = chatgpt_client.complete(
+            [
+                ChatMessage(role="system", content=system_prompt),
+                ChatMessage(role="user", content=f"{user_prompt}\n\nEmail body:\n{body_text}"),
+            ]
+        )
+        return SummarizeResponse(message_id=payload.message_id, summary=summary.strip())
+
+    @app.post("/send", response_model=dict)
+    def send_email(
+        draft: DraftEmail,
+        gmail_client: Annotated[GmailClient, Depends(get_gmail_client)],
+        chatgpt_client: Annotated[ChatGPTClient, Depends(get_chatgpt_client)],
+        personalize: bool = False,
+    ):
+        body = draft.body
+        if personalize:
+            body = chatgpt_client.complete(
+                [
+                    ChatMessage(role="system", content="You help polish outgoing emails before they are sent."),
+                    ChatMessage(
+                        role="user",
+                        content=(
+                            "Polish the following email for clarity and professionalism while keeping the intent intact:\n" + draft.body
+                        ),
+                    ),
+                ]
+            )
+        result = gmail_client.send_message(draft.to, draft.subject, body)
+        return {"id": result.get("id"), "threadId": result.get("threadId")}
+
+    return app
+
+
+app = create_app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gmail-mcp-service"
+version = "0.1.0"
+description = "Model Context Protocol service that bridges Gmail with ChatGPT"
+authors = [{name = "Your Name", email = "you@example.com"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "google-auth",
+    "google-auth-oauthlib",
+    "google-api-python-client",
+    "openai",
+    "pydantic>=1.10,<3",
+    "python-dotenv"
+]
+
+[project.optional-dependencies]
+development = [
+    "pytest",
+    "requests"
+]
+
+[project.urls]
+Homepage = "https://example.com"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,20 @@
+"""Basic smoke tests for the Gmail MCP service package."""
+
+from gmail_mcp_service import ChatGPTClient, GmailClient, Settings, create_app
+
+
+def test_create_app():
+    app = create_app()
+    assert app.title == "Gmail MCP Service"
+
+
+def test_settings_env(tmp_path, monkeypatch):
+    secret_file = tmp_path / "client_secret.json"
+    secret_file.write_text("{}")
+    token_file = tmp_path / "token.json"
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_FILE", str(secret_file))
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("GMAIL_TOKEN_FILE", str(token_file))
+    settings = Settings()
+    assert settings.google_client_secret_file == secret_file.resolve()
+    assert settings.gmail_token_file == token_file.resolve()


### PR DESCRIPTION
## Summary
- add a FastAPI-based Gmail MCP service package that wraps Gmail and ChatGPT interactions
- expose configuration utilities, Gmail and OpenAI clients, and HTTP endpoints for listing, summarising, and sending emails
- document setup steps, configuration, and ChatGPT MCP client integration in the README

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'gmail_mcp_service' caused by missing optional dependencies such as pydantic/fastapi in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce62f2b7488328a233c55e98dc1bd8